### PR TITLE
Fixed command logging.

### DIFF
--- a/splparser/__init__.py
+++ b/splparser/__init__.py
@@ -5,9 +5,10 @@ from splparser.parser import SPLParser
 
 PARSETAB = 'toplevel_parsetab'
 PARSETAB_DIR = 'parsetabs'
+LOGNAME = 'splparser'
 
 def parse(data):
-    parser = SPLParser(splparser.lexers.toplevellexer, PARSETAB, PARSETAB_DIR, splparser.rules.toplevelrules)
+    parser = SPLParser(splparser.lexers.toplevellexer, PARSETAB, PARSETAB_DIR, LOGNAME, splparser.rules.toplevelrules)
     return parser.parse(data)
 
 if __name__ == "__main__":

--- a/splparser/decorators.py
+++ b/splparser/decorators.py
@@ -6,13 +6,14 @@ OPTIMIZE = False
 
 def splcommandrule(f):
     cmd = f.__doc__.split(':')[1].split()[0].strip().lower()
-    cmdlexer = 'splparser.lexers.' + cmd + 'lexer'
-    cmdlexer = __import__(cmdlexer, fromlist=['__import__ is dumb'])
-    cmdparsetab = cmd + '_parsetab'
-    cmdparsetab_dir = 'parsetabs'
-    cmdrules = 'splparser.rules.' + cmd + 'rules'
-    cmdrules = __import__(cmdrules, fromlist=['fromlist does nothing'])
-    parser = SPLParser(cmdlexer, cmdparsetab, cmdparsetab_dir, cmdrules, optimize=OPTIMIZE)
+    cmdlexer = "splparser.lexers." + cmd + "lexer"
+    cmdlexer = __import__(cmdlexer, fromlist=["__import__ is dumb"])
+    cmdparsetab = cmd + "_parsetab"
+    cmdparsetab_dir = "parsetabs"
+    cmdlogname = cmd + "rules"
+    cmdrules = "splparser.rules." + cmd + "rules"
+    cmdrules = __import__(cmdrules, fromlist=["fromlist does nothing"])
+    parser = SPLParser(cmdlexer, cmdparsetab, cmdparsetab_dir, cmdlogname, cmdrules, optimize=OPTIMIZE)
     def helper(p):
         try:
             p[0]  = parser.parse(' '.join(p[1:]))


### PR DESCRIPTION
Fixed logging so that all commands now write log messages to `logs/<cmd>rules.log`. Logging was previously broken by the move to classes because debugging was turned off. This commit turns it back on and also gives each rule it's own logger, and organizes all logs into a `logs` directory.
