### PR TITLE
Link to GitHub

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,12 +8,16 @@ setuptools.setup(
     
     name = "splparser",
     version = "0.2.0",
-    url = "http://pypi.python.org/splparser",
+    url = "https://pypi.org/project/splparser/",
+    project_urls = {
+        "GitHub" : "https://github.com/salspaugh/splparser",
+    },
     author = "Sara Alspaugh",
     author_email = "saraalspaugh@gmail.com",
     license = "BSD",
     description = ("A simple parser for the Splunk Processing Language which emits parse trees."),
-    long_description=read('README'),
+    long_description=read('README.md'),
+    long_description_content_type="text/markdown",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",


### PR DESCRIPTION
Found this on PyPI, saw that pull requests were welcome but no link to GitHub was provided.  Trivial patch to add a link.

- Add URL for GitHub code
- Fixed PyPI link.
- Correct README file name  (add .md extension)
- Mark description text as being in markdown format (very minor)